### PR TITLE
Variant preferences with open slots for lemmas

### DIFF
--- a/apertium-nno.nno.prefs.rlx
+++ b/apertium-nno.nno.prefs.rlx
@@ -1,4 +1,4 @@
-# -*- cg-pre-pipe: "lt-proc -N1 nno.automorf.bin|sed 's,\\^[^/]*/,^,g' | lt-proc -b nno_e_vi.autogen.bin"; cg-command: "~/src/ap/vislcg3/src/cg-proc"; cg-extra-args: "-t -g -n -z apertium-nno.nno.prefs.rlx # " -*-
+# -*- cg-pre-pipe: "lt-proc -N1 nno.automorf.bin|sed 's,\\^[^/]*/,^,g' | lt-proc -b nno.autogen.bin"; cg-extra-args: "-t -g -n -z apertium-nno.nno.prefs.rlx # " -*-
 # GPL-2+
 #
 # Generator dictionary preference rules.
@@ -7,10 +7,19 @@
 # scheme "VAR:default_override", where "override" is chosen if set,
 # otherwise "default" is chosen. For any "default", there may be
 # multiple possible "override"''s.
+#
+# Lemma-specific and exceptional rules are in the beginning of this
+# file, simple rules towards the end.
 
 DELIMITERS = ".";
 
-# Handle kløyvd infinitiv here since it's a specific set of words that partially override infa_infe:
+########################
+# Unusual rules first: #
+########################
+
+# Kløyvd Infinitiv
+#
+# Handled in prefs.rlx instead of .dix since it's a specific set of words that partially override infa_infe:
 LIST kløyvd_a = "age" "ake" "ale" "ane" "ape" "ase" "bake" "bale" "bane" "base" "bede" "belje" "bere" "betale" "beve" "bevare" "blade" "blike" "bode" "bore" "bose" "brage" "brake" "brase" "byrje" "dage" "dale" "dane" "delje" "dette" "drage" "drepe" "drynje" "drysje" "dune" "dvelje" "dynje" "dølje" "ete" "eve" "fare" "fate" "ferje" "flage" "flare" "flasse" "flase" "flate" "flòte" "flysje" "flytte" "fole" "frede" "frege" "fremje" "frode" "gage" "gale" "gane" "gape" "gilje" "gjere" "gjete" "gidde" "gjeve" "glade" "glane" "glede" "glume" "gnage" "gnike" "gove" "grave" "gremje" "grope" "grune" "grysje" "gule" "gysje" "hage" "hake" "hame" "hate" "have" "hele" "hemje" "herje" "hesje" "hete" "hevje" "hjale" "hòle" "homme" "home" "hòpe" "hylje" "hysje" "hølje" "jage" "kake" "kare" "kave" "kjase" "kjee" "klage" "klake" "klede" "kløvje" "knake" "knase" "knise" "knode" "kole" "komme" "kome" "krake" "krase" "krave" "kreke" "krevje" "krite" "krote" "kunne" "kvede" "kvetje" "kvike" "kvime" "lade" "lage" "lape" "late" "lave" "lede" "lee" "leke" "lemme" "leme" "lemje" "lepje" "lese" "léte" "lete" "love" "lute" "make" "male" "mane" "mase" "mate" "mede" "moke" "mole" "mone" "møkje" "nase" "nave" "neve" "olboge" "pare" "pele" "pese" "pose" "prate" "rage" "rake" "rane" "rape" "rase" "reke" "remje" "reve" "rode" "rydje" "rysje" "sage" "sake" "same" "sede" "seie" "sele" "selje" "semje" "setja/sette" "sitja/sitte" "skade" "skake" "skale" "skape" "skare" "skave" "skilje" "skipe" "skjage" "sjage" "skjene" "skjere" "skjønne" "skjøne" "skode" "skòle" "skòre" "skote" "skrape" "skrate" "skreve" "skulle" "skule" "skvale" "skylje" "slave" "sleve" "smake" "smale" "smørje" "snake" "snare" "snase" "sove" "spade" "spare" "spekje" "spele" "spore" "sprake" "sprale" "spørje" "spøte" "stage" "stake" "stave" "stede" "stege" "stele" "stote" "streka " "strete" "streve" "stynje" "styrje" "svade" "svage" "svale" "svare" "svemje" "sverje" "svipe" "symje" "take" "tale" "tane" "tape" "tase" "teie" "tele" "telje" "temje" "tenje" "tevje" "timje" "tole" "tore" "tose" "trede" "trege" "trote" "tvike" "tvoge" "tysje" "umake" "une" "uvete" "uvite" "vade" "vake" "vare" "vase" "vege" "velje" "venje" "vere" "verje" "vete" "veve" "vevje" "vilje" "vime" "vite" "vrake" "ylje" "yrje" "ølje" "åtvare" ;
 
 # For v:kløyvd_inf, we only select e-inf if it's *not* part of the kløyvd_a set:
@@ -19,7 +28,292 @@ SELECT (v:infa_infe) IF (0 (VAR:kløyvd_inf)) (NEGATE 0 kløyvd_a) ;
 SELECT (v:infa_infe) IF (0 (VAR:infa_infe)) ;
 REMOVE (v:infa_infe) ;
 
-# The rest are quite straightforward:
+
+# Open Lemma Slots
+#
+# Preferences with open slots for lemmas start with an underscore.
+#
+# If you set AP_SETVAR="_er_ar" you should get -er→-ar for all the
+# forms that have that tag, but if you instead
+# AP_SETVAR="grue_er_ar,male_er_ar", then you only get _er_ar for
+# those specific lemmas.
+#
+# NB. Rules match lemmas on "<wordforms>" – since this is input to
+# generator, wordforms/lemmas are backwards.
+#
+# Ideally we could use a regex to avoid the duplication, but
+# that requires support for varstring regex keys
+# https://github.com/GrammarSoft/cg3/issues/109
+# When ↑ gets solved we can replace the below long list with ↓
+# SELECT:varstring-regex (v:_er_ar) IF (0 (/^VAR:\(.*\)_er_ar$/r)) (0 ("<.*\\b$1\\b.*>"v)) ;
+#
+# Dirty one-liner to find all lemmas that can use a certain var-tag:
+# $ grep -Ff <(awk '/<pardef /{p=$0}/<\/pardef/{p=""}/:_er_ar/&&p{print p}' apertium-nno.nno.dix |sort -u|sed 's, c=.*,,'|grep -v ':_er_ar' |sed 's,def,,' ) apertium-nno.nno.dix |grep -o 'lm="[^"]*"'|sed 's,^lm=,,'
+#
+# Some of the below do regex-matching to include multiwords, e.g.
+# AP_SETVAR="lene_er_ar" should also affect "lene seg".
+
+SELECT (v:_er_ar) IF (0 (VAR:ane_er_ar))               (0 ("<ane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:anrope_er_ar))            (0 ("<anrope>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:ape_er_ar))               (0 ("<ape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:atterskape_er_ar))        (0 ("<atterskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:attskape_er_ar))          (0 ("<attskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avbetale_er_ar))          (0 ("<avbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avekse_er_ar))            (0 ("<avekse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avklare_er_ar))           (0 ("<avklare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avkoke_er_ar))            (0 ("<avkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avlure_er_ar))            (0 ("<avlure>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avlute_er_ar))            (0 ("<avlute>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avmerke_er_ar))           (0 ("<avmerke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avmåle_er_ar))            (0 ("<avmåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avsile_er_ar))            (0 ("<avsile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avskape_er_ar))           (0 ("<avskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avsløre_er_ar))           (0 ("<avsløre>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:avtale_er_ar))            (0 ("<avtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bake_er_ar))              (0 ("<bake>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:banne_er_ar))             (0 ("<banne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:beføle_er_ar))            (0 ("<beføle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:berke_er_ar))             (0 ("<berke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bestråle_er_ar))          (0 ("<bestråle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:betale_er_ar))            (0 ("<betale\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:bie_er_ar))               (0 ("<bie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bile_er_ar))              (0 ("<bile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:blankslipe_er_ar))        (0 ("<blankslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:blautkoke_er_ar))         (0 ("<blautkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bortforklare_er_ar))      (0 ("<bortforklare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:breke_er_ar))             (0 ("<breke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bruke_er_ar))             (0 ("<bruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bruse_er_ar))             (0 ("<bruse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:bræke_er_ar))             (0 ("<bræke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:brøle_er_ar))             (0 ("<brøle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:buse_er_ar))              (0 ("<buse\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:buskape_er_ar))           (0 ("<buskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:dale_er_ar))              (0 ("<dale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:dibbe_er_ar))             (0 ("<dibbe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:dreie_er_ar))             (0 ("<dreie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:duse_er_ar))              (0 ("<duse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:egse_er_ar))              (0 ("<egse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:eine_er_ar))              (0 ("<eine>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:einglane_er_ar))          (0 ("<einglane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:ekse_er_ar))              (0 ("<ekse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:etterape_er_ar))          (0 ("<etterape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:etterbetale_er_ar))       (0 ("<etterbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:feike_er_ar))             (0 ("<feike>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fike_er_ar))              (0 ("<fike>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:file_er_ar))              (0 ("<file\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:finslipe_er_ar))          (0 ("<finslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:flise_er_ar))             (0 ("<flise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forbanne_er_ar))          (0 ("<forbanne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forbruke_er_ar))          (0 ("<forbruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fordøye_er_ar))           (0 ("<fordøye>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forhale_er_ar))           (0 ("<forhale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forklare_er_ar))          (0 ("<forklare\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:formane_er_ar))           (0 ("<formane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forskottsbetale_er_ar))   (0 ("<forskottsbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forskylde_er_ar))         (0 ("<forskylde>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:forsvare_er_ar))          (0 ("<forsvare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fortale_er_ar))           (0 ("<fortale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fortrylle_er_ar))         (0 ("<fortrylle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fortøye_er_ar))           (0 ("<fortøye>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fosskoke_er_ar))          (0 ("<fosskoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:frålure_er_ar))           (0 ("<frålure>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:fullrose_er_ar))          (0 ("<fullrose>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:føle_er_ar))              (0 ("<føle\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:føne_er_ar))              (0 ("<føne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:føre_er_ar))              (0 ("<føre\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:førehandsinnspele_er_ar)) (0 ("<førehandsinnspele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:førehandsomtale_er_ar))   (0 ("<førehandsomtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gane_er_ar))              (0 ("<gane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gine_er_ar))              (0 ("<gine>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gise_er_ar))              (0 ("<gise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gjenbruke_er_ar))         (0 ("<gjenbruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gjenskape_er_ar))         (0 ("<gjenskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gjepe_er_ar))             (0 ("<gjepe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gjestespele_er_ar))       (0 ("<gjestespele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:glane_er_ar))             (0 ("<glane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:glattslipe_er_ar))        (0 ("<glattslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:glenne_er_ar))            (0 ("<glenne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:gnise_er_ar))             (0 ("<gnise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:godtale_er_ar))           (0 ("<godtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:grue_er_ar))              (0 ("<grue>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hale_er_ar))              (0 ("<hale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:halvklare_er_ar))         (0 ("<halvklare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hardkoke_er_ar))          (0 ("<hardkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hardtrene_er_ar))         (0 ("<hardtrene>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:heise_er_ar))             (0 ("<heise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hekse_er_ar))             (0 ("<hekse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:henslepe_er_ar))          (0 ("<henslepe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hole_er_ar))              (0 ("<hole\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:huke_er_ar))              (0 ("<huke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hyfse_er_ar))             (0 ("<hyfse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:hyle_er_ar))              (0 ("<hyle\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:håle_er_ar))              (0 ("<håle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:håne_er_ar))              (0 ("<håne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:håpe_er_ar))              (0 ("<håpe\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:innbetale_er_ar))         (0 ("<innbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:innspele_er_ar))          (0 ("<innspele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:jule_er_ar))              (0 ("<jule>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:jåle_er_ar))              (0 ("<jåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kapasitetsmåle_er_ar))    (0 ("<kapasitetsmåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kile_er_ar))              (0 ("<kile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kise_er_ar))              (0 ("<kise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kjølhale_er_ar))          (0 ("<kjølhale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:klare_er_ar))             (0 ("<klare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kleie_er_ar))             (0 ("<kleie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:klosshale_er_ar))         (0 ("<klosshale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:knise_er_ar))             (0 ("<knise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:koke_er_ar))              (0 ("<koke\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:koke_er_ar))              (0 ("<koke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kontrollmåle_er_ar))      (0 ("<kontrollmåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kose_er_ar))              (0 ("<kose>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kruke_er_ar))             (0 ("<kruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kryssbruke_er_ar))        (0 ("<kryssbruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kukelure_er_ar))          (0 ("<kukelure>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kule_er_ar))              (0 ("<kule\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:kute_er_ar))              (0 ("<kute>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:kyle_er_ar))              (0 ("<kyle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:langkoke_er_ar))          (0 ("<langkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:leie_er_ar))              (0 ("<leie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lene_er_ar))              (0 ("<lene\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:like_er_ar))              (0 ("<like>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:linnkoke_er_ar))          (0 ("<linnkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lire_er_ar))              (0 ("<lire>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lose_er_ar))              (0 ("<lose>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lòse_er_ar))              (0 ("<lòse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:luke_er_ar))              (0 ("<luke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lure_er_ar))              (0 ("<lure>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:lyne_er_ar))              (0 ("<lyne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:mane_er_ar))              (0 ("<mane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:mine_er_ar))              (0 ("<mine>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:misbruke_er_ar))          (0 ("<misbruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:mislike_er_ar))           (0 ("<mislike>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:mistale_er_ar))           (0 ("<mistale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:mistvile_er_ar))          (0 ("<mistvile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:motsvare_er_ar))          (0 ("<motsvare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:måle_er_ar))              (0 ("<måle\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:måpe_er_ar))              (0 ("<måpe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:nedbetale_er_ar))         (0 ("<nedbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:nevehelse_er_ar))         (0 ("<nevehelse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:niglane_er_ar))           (0 ("<niglane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:nyskape_er_ar))           (0 ("<nyskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:oljegruse_er_ar))         (0 ("<oljegruse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:omnsbake_er_ar))          (0 ("<omnsbake>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:omskape_er_ar))           (0 ("<omskape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:omtale_er_ar))            (0 ("<omtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:oppklare_er_ar))          (0 ("<oppklare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:oppmane_er_ar))           (0 ("<oppmane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:ose_er_ar))               (0 ("<ose>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:overforbruke_er_ar))      (0 ("<overforbruke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:overhale_er_ar))          (0 ("<overhale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:overspele_er_ar))         (0 ("<overspele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:overstråle_er_ar))        (0 ("<overstråle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:overtale_er_ar))          (0 ("<overtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:pace_er_ar))              (0 ("<pace>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:pale_er_ar))              (0 ("<pale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:peke_er_ar))              (0 ("<peke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:pile_er_ar))              (0 ("<pile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:prise_er_ar))             (0 ("<prise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:prøvespele_er_ar))        (0 ("<prøvespele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:pøse_er_ar))              (0 ("<pøse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:påskjøne_er_ar))          (0 ("<påskjøne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:påskjønne_er_ar))         (0 ("<påskjønne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:påtale_er_ar))            (0 ("<påtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:rope_er_ar))              (0 ("<rope\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:rundjule_er_ar))          (0 ("<rundjule>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:rundlure_er_ar))          (0 ("<rundlure>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:rundspele_er_ar))         (0 ("<rundspele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:råskrelle_er_ar))         (0 ("<råskrelle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:samsvare_er_ar))          (0 ("<.*\\bsamsvare\\b.*>")) ; # \\b before too because "ikkje samsvarre med"
+SELECT (v:_er_ar) IF (0 (VAR:samtale_er_ar))           (0 ("<samtale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sile_er_ar))              (0 ("<sile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sipe_er_ar))              (0 ("<sipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sjørøverskute_er_ar))     (0 ("<sjørøverskute>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skamfile_er_ar))          (0 ("<skamfile>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skape_er_ar))             (0 ("<skape\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:skarpslipe_er_ar))        (0 ("<skarpslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skjøne_er_ar))            (0 ("<skjøne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skjønne_er_ar))           (0 ("<skjønne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skrøne_er_ar))            (0 ("<skrøne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skråle_er_ar))            (0 ("<skråle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skule_er_ar))             (0 ("<skule>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skute_er_ar))             (0 ("<skute>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skye_er_ar))              (0 ("<skye>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skylde_er_ar))            (0 ("<skylde>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:skåle_er_ar))             (0 ("<skåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:slemme_er_ar))            (0 ("<slemme>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:slepe_er_ar))             (0 ("<slepe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:slipe_er_ar))             (0 ("<slipe\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:slute_er_ar))             (0 ("<slute>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:smake_er_ar))             (0 ("<smake\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:smie_er_ar))              (0 ("<smie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:småkoke_er_ar))           (0 ("<småkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:småspise_er_ar))          (0 ("<småspise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:snuse_er_ar))             (0 ("<snuse\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:snøbake_er_ar))           (0 ("<snøbake>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sope_er_ar))              (0 ("<sope>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:spare_er_ar))             (0 ("<spare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:spele_er_ar))             (0 ("<spele\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:spike_er_ar))             (0 ("<spike>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:spise_er_ar))             (0 ("<spise>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:spjære_er_ar))            (0 ("<spjære>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sprele_er_ar))            (0 ("<sprele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sprene_er_ar))            (0 ("<sprene>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:sprøyte_er_ar))           (0 ("<sprøyte\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:stire_er_ar))             (0 ("<stire>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:stole_er_ar))             (0 ("<stole>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:storspele_er_ar))         (0 ("<storspele>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:stræne_er_ar))            (0 ("<stræne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:stråle_er_ar))            (0 ("<stråle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:suse_er_ar))              (0 ("<suse>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:svare_er_ar))             (0 ("<svare\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:tale_er_ar))              (0 ("<tale\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:tape_er_ar))              (0 ("<tape>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tilbakebetale_er_ar))     (0 ("<tilbakebetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tilmåle_er_ar))           (0 ("<tilmåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tilsvare_er_ar))          (0 ("<tilsvare>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tiltale_er_ar))           (0 ("<tiltale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tine_er_ar))              (0 ("<tine\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:tole_er_ar))              (0 ("<tole>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:trale_er_ar))             (0 ("<trale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:trykkoke_er_ar))          (0 ("<trykkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:trylle_er_ar))            (0 ("<trylle\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:turrbanne_er_ar))         (0 ("<turrbanne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:turrkoke_er_ar))          (0 ("<turrkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tverrstane_er_ar))        (0 ("<tverrstane>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tvile_er_ar))             (0 ("<tvile\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:tylle_er_ar))             (0 ("<tylle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tynne_er_ar))             (0 ("<tynne\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:tynnslipe_er_ar))         (0 ("<tynnslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tøle_er_ar))              (0 ("<tøle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tørrbanne_er_ar))         (0 ("<tørrbanne>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:tørrkoke_er_ar))          (0 ("<tørrkoke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:ule_er_ar))               (0 ("<ule>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:underbetale_er_ar))       (0 ("<underbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:utbetale_er_ar))          (0 ("<utbetale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:uthole_er_ar))            (0 ("<uthole>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:utmerke_er_ar))           (0 ("<utmerke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:utmåle_er_ar))            (0 ("<utmåle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:utrope_er_ar))            (0 ("<utrope>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:utstråle_er_ar))          (0 ("<utstråle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:uttale_er_ar))            (0 ("<uttale>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:vake_er_ar))              (0 ("<vake>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:vare_er_ar))              (0 ("<vare\\b.*>"r)) ;
+SELECT (v:_er_ar) IF (0 (VAR:vasslipe_er_ar))          (0 ("<vasslipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:vass-slipe_er_ar))        (0 ("<vass-slipe>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:vegleie_er_ar))           (0 ("<vegleie>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:virke_er_ar))             (0 ("<virke>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:vræle_er_ar))             (0 ("<vræle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:øle_er_ar))               (0 ("<øle>")) ;
+SELECT (v:_er_ar) IF (0 (VAR:åle_er_ar))               (0 ("<åle\\b.*>"r)) ;
+
+# and if none of the above just treat it like the simple rules:
+SELECT (v:_er_ar) IF (0 (VAR:_er_ar)) ;
+REMOVE (v:_er_ar) ;
+
+
+#####################
+# The simple rules: #
+#####################
 
 SELECT (v:tenkje-leggje.kons-kj2k_gj2g)        IF (0 (VAR:tenkje-leggje.kons-kj2k_gj2g)) ;
 REMOVE (v:tenkje-leggje.kons-kj2k_gj2g) ;
@@ -47,9 +341,6 @@ REMOVE (v:medan_mens) ;
 
 SELECT (v:me_vi) IF (0 (VAR:me_vi)) ;
 REMOVE (v:me_vi) ;
-
-SELECT (v:er_ar) IF (0 (VAR:er_ar)) ;
-REMOVE (v:er_ar) ;
 
 SELECT (v:stader_stadar.subst-ene2ane) IF (0 (VAR:stader_stadar.subst-ene2ane)) ;
 REMOVE (v:stader_stadar.subst-ene2ane) ;

--- a/nno.preferences.xml
+++ b/nno.preferences.xml
@@ -36,9 +36,1017 @@
   <preference id="me_vi">
     <description lang="nno">me → vi</description>
   </preference>
-  <preference id="er_ar">
-    <description lang="nno">roper → ropar, stader → stadar (-er/-te/-t → -ar/-a/-a om mogleg, -ane i subst)</description>
-    <description lang="nob">roper → ropar, stader → stadar (-er/-te/-t → -ar/-a/-a om mulig, -ane i subst)</description>
+  <preference id="ane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ane</description>
+  </preference>
+  <preference id="anrope_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for anrope</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for anrope</description>
+  </preference>
+  <preference id="ape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ape</description>
+  </preference>
+  <preference id="atterskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for atterskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for atterskape</description>
+  </preference>
+  <preference id="attskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for attskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for attskape</description>
+  </preference>
+  <preference id="avbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avbetale</description>
+  </preference>
+  <preference id="avekse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avekse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avekse</description>
+  </preference>
+  <preference id="avklare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avklare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avklare</description>
+  </preference>
+  <preference id="avkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avkoke</description>
+  </preference>
+  <preference id="avlure_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avlure</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avlure</description>
+  </preference>
+  <preference id="avlute_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avlute</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avlute</description>
+  </preference>
+  <preference id="avmerke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avmerke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avmerke</description>
+  </preference>
+  <preference id="avmåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avmåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avmåle</description>
+  </preference>
+  <preference id="avsile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avsile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avsile</description>
+  </preference>
+  <preference id="avskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avskape</description>
+  </preference>
+  <preference id="avsløre_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avsløre</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avsløre</description>
+  </preference>
+  <preference id="avtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for avtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for avtale</description>
+  </preference>
+  <preference id="bake_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bake</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bake</description>
+  </preference>
+  <preference id="banne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for banne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for banne</description>
+  </preference>
+  <preference id="beføle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for beføle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for beføle</description>
+  </preference>
+  <preference id="berke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for berke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for berke</description>
+  </preference>
+  <preference id="bestråle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bestråle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bestråle</description>
+  </preference>
+  <preference id="betale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for betale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for betale</description>
+  </preference>
+  <preference id="bie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bie</description>
+  </preference>
+  <preference id="bile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bile</description>
+  </preference>
+  <preference id="blankslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for blankslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for blankslipe</description>
+  </preference>
+  <preference id="blautkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for blautkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for blautkoke</description>
+  </preference>
+  <preference id="bortforklare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bortforklare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bortforklare</description>
+  </preference>
+  <preference id="breke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for breke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for breke</description>
+  </preference>
+  <preference id="bruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bruke</description>
+  </preference>
+  <preference id="bruse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bruse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bruse</description>
+  </preference>
+  <preference id="bræke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for bræke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for bræke</description>
+  </preference>
+  <preference id="brøle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for brøle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for brøle</description>
+  </preference>
+  <preference id="buse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for buse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for buse</description>
+  </preference>
+  <preference id="buskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for buskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for buskape</description>
+  </preference>
+  <preference id="dale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for dale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for dale</description>
+  </preference>
+  <preference id="dibbe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for dibbe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for dibbe</description>
+  </preference>
+  <preference id="dreie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for dreie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for dreie</description>
+  </preference>
+  <preference id="duse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for duse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for duse</description>
+  </preference>
+  <preference id="egse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for egse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for egse</description>
+  </preference>
+  <preference id="eine_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for eine</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for eine</description>
+  </preference>
+  <preference id="einglane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for einglane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for einglane</description>
+  </preference>
+  <preference id="ekse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ekse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ekse</description>
+  </preference>
+  <preference id="etterape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for etterape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for etterape</description>
+  </preference>
+  <preference id="etterbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for etterbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for etterbetale</description>
+  </preference>
+  <preference id="feike_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for feike</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for feike</description>
+  </preference>
+  <preference id="fike_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fike</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fike</description>
+  </preference>
+  <preference id="file_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for file</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for file</description>
+  </preference>
+  <preference id="finslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for finslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for finslipe</description>
+  </preference>
+  <preference id="flise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for flise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for flise</description>
+  </preference>
+  <preference id="forbanne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forbanne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forbanne</description>
+  </preference>
+  <preference id="forbruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forbruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forbruke</description>
+  </preference>
+  <preference id="fordøye_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fordøye</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fordøye</description>
+  </preference>
+  <preference id="forhale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forhale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forhale</description>
+  </preference>
+  <preference id="forklare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forklare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forklare</description>
+  </preference>
+  <preference id="formane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for formane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for formane</description>
+  </preference>
+  <preference id="forskottsbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forskottsbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forskottsbetale</description>
+  </preference>
+  <preference id="forskylde_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forskylde</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forskylde</description>
+  </preference>
+  <preference id="forsvare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for forsvare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for forsvare</description>
+  </preference>
+  <preference id="fortale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fortale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fortale</description>
+  </preference>
+  <preference id="fortrylle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fortrylle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fortrylle</description>
+  </preference>
+  <preference id="fortøye_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fortøye</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fortøye</description>
+  </preference>
+  <preference id="fosskoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fosskoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fosskoke</description>
+  </preference>
+  <preference id="frålure_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for frålure</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for frålure</description>
+  </preference>
+  <preference id="fullrose_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for fullrose</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for fullrose</description>
+  </preference>
+  <preference id="føle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for føle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for føle</description>
+  </preference>
+  <preference id="føne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for føne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for føne</description>
+  </preference>
+  <preference id="føre_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for føre</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for føre</description>
+  </preference>
+  <preference id="førehandsinnspele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for førehandsinnspele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for førehandsinnspele</description>
+  </preference>
+  <preference id="førehandsomtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for førehandsomtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for førehandsomtale</description>
+  </preference>
+  <preference id="gane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gane</description>
+  </preference>
+  <preference id="gine_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gine</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gine</description>
+  </preference>
+  <preference id="gise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gise</description>
+  </preference>
+  <preference id="gjenbruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gjenbruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gjenbruke</description>
+  </preference>
+  <preference id="gjenskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gjenskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gjenskape</description>
+  </preference>
+  <preference id="gjepe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gjepe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gjepe</description>
+  </preference>
+  <preference id="gjestespele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gjestespele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gjestespele</description>
+  </preference>
+  <preference id="glane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for glane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for glane</description>
+  </preference>
+  <preference id="glattslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for glattslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for glattslipe</description>
+  </preference>
+  <preference id="glenne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for glenne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for glenne</description>
+  </preference>
+  <preference id="gnise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for gnise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for gnise</description>
+  </preference>
+  <preference id="godtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for godtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for godtale</description>
+  </preference>
+  <preference id="grue_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for grue</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for grue</description>
+  </preference>
+  <preference id="hale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hale</description>
+  </preference>
+  <preference id="halvklare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for halvklare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for halvklare</description>
+  </preference>
+  <preference id="hardkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hardkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hardkoke</description>
+  </preference>
+  <preference id="hardtrene_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hardtrene</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hardtrene</description>
+  </preference>
+  <preference id="heise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for heise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for heise</description>
+  </preference>
+  <preference id="hekse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hekse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hekse</description>
+  </preference>
+  <preference id="henslepe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for henslepe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for henslepe</description>
+  </preference>
+  <preference id="hole_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hole</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hole</description>
+  </preference>
+  <preference id="huke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for huke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for huke</description>
+  </preference>
+  <preference id="hyfse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hyfse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hyfse</description>
+  </preference>
+  <preference id="hyle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for hyle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for hyle</description>
+  </preference>
+  <preference id="håle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for håle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for håle</description>
+  </preference>
+  <preference id="håne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for håne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for håne</description>
+  </preference>
+  <preference id="håpe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for håpe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for håpe</description>
+  </preference>
+  <preference id="ikkje_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ikkje</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ikkje</description>
+  </preference>
+  <preference id="innbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for innbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for innbetale</description>
+  </preference>
+  <preference id="innspele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for innspele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for innspele</description>
+  </preference>
+  <preference id="jule_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for jule</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for jule</description>
+  </preference>
+  <preference id="jåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for jåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for jåle</description>
+  </preference>
+  <preference id="kapasitetsmåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kapasitetsmåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kapasitetsmåle</description>
+  </preference>
+  <preference id="kile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kile</description>
+  </preference>
+  <preference id="kise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kise</description>
+  </preference>
+  <preference id="kjølhale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kjølhale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kjølhale</description>
+  </preference>
+  <preference id="klare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for klare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for klare</description>
+  </preference>
+  <preference id="kleie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kleie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kleie</description>
+  </preference>
+  <preference id="klosshale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for klosshale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for klosshale</description>
+  </preference>
+  <preference id="knise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for knise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for knise</description>
+  </preference>
+  <preference id="koke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for koke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for koke</description>
+  </preference>
+  <preference id="kontrollmåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kontrollmåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kontrollmåle</description>
+  </preference>
+  <preference id="kose_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kose</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kose</description>
+  </preference>
+  <preference id="kruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kruke</description>
+  </preference>
+  <preference id="kryssbruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kryssbruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kryssbruke</description>
+  </preference>
+  <preference id="kukelure_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kukelure</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kukelure</description>
+  </preference>
+  <preference id="kule_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kule</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kule</description>
+  </preference>
+  <preference id="kute_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kute</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kute</description>
+  </preference>
+  <preference id="kyle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for kyle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for kyle</description>
+  </preference>
+  <preference id="langkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for langkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for langkoke</description>
+  </preference>
+  <preference id="leie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for leie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for leie</description>
+  </preference>
+  <preference id="lene_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lene</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lene</description>
+  </preference>
+  <preference id="like_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for like</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for like</description>
+  </preference>
+  <preference id="linnkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for linnkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for linnkoke</description>
+  </preference>
+  <preference id="lire_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lire</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lire</description>
+  </preference>
+  <preference id="lose_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lose</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lose</description>
+  </preference>
+  <preference id="lòse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lòse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lòse</description>
+  </preference>
+  <preference id="luke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for luke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for luke</description>
+  </preference>
+  <preference id="lure_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lure</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lure</description>
+  </preference>
+  <preference id="lyne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for lyne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for lyne</description>
+  </preference>
+  <preference id="mane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for mane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for mane</description>
+  </preference>
+  <preference id="mine_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for mine</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for mine</description>
+  </preference>
+  <preference id="misbruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for misbruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for misbruke</description>
+  </preference>
+  <preference id="mislike_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for mislike</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for mislike</description>
+  </preference>
+  <preference id="mistale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for mistale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for mistale</description>
+  </preference>
+  <preference id="mistvile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for mistvile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for mistvile</description>
+  </preference>
+  <preference id="motsvare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for motsvare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for motsvare</description>
+  </preference>
+  <preference id="måle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for måle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for måle</description>
+  </preference>
+  <preference id="måpe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for måpe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for måpe</description>
+  </preference>
+  <preference id="nedbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for nedbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for nedbetale</description>
+  </preference>
+  <preference id="nevehelse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for nevehelse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for nevehelse</description>
+  </preference>
+  <preference id="niglane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for niglane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for niglane</description>
+  </preference>
+  <preference id="nyskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for nyskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for nyskape</description>
+  </preference>
+  <preference id="oljegruse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for oljegruse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for oljegruse</description>
+  </preference>
+  <preference id="omnsbake_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for omnsbake</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for omnsbake</description>
+  </preference>
+  <preference id="omskape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for omskape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for omskape</description>
+  </preference>
+  <preference id="omtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for omtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for omtale</description>
+  </preference>
+  <preference id="oppklare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for oppklare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for oppklare</description>
+  </preference>
+  <preference id="oppmane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for oppmane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for oppmane</description>
+  </preference>
+  <preference id="ose_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ose</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ose</description>
+  </preference>
+  <preference id="overforbruke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for overforbruke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for overforbruke</description>
+  </preference>
+  <preference id="overhale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for overhale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for overhale</description>
+  </preference>
+  <preference id="overspele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for overspele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for overspele</description>
+  </preference>
+  <preference id="overstråle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for overstråle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for overstråle</description>
+  </preference>
+  <preference id="overtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for overtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for overtale</description>
+  </preference>
+  <preference id="pace_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for pace</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for pace</description>
+  </preference>
+  <preference id="pale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for pale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for pale</description>
+  </preference>
+  <preference id="peke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for peke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for peke</description>
+  </preference>
+  <preference id="pile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for pile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for pile</description>
+  </preference>
+  <preference id="prise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for prise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for prise</description>
+  </preference>
+  <preference id="prøvespele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for prøvespele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for prøvespele</description>
+  </preference>
+  <preference id="pøse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for pøse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for pøse</description>
+  </preference>
+  <preference id="påskjøne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for påskjøne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for påskjøne</description>
+  </preference>
+  <preference id="påskjønne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for påskjønne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for påskjønne</description>
+  </preference>
+  <preference id="påtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for påtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for påtale</description>
+  </preference>
+  <preference id="rope_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for rope</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for rope</description>
+  </preference>
+  <preference id="rundjule_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for rundjule</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for rundjule</description>
+  </preference>
+  <preference id="rundlure_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for rundlure</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for rundlure</description>
+  </preference>
+  <preference id="rundspele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for rundspele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for rundspele</description>
+  </preference>
+  <preference id="råskrelle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for råskrelle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for råskrelle</description>
+  </preference>
+  <preference id="samsvare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for samsvare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for samsvare</description>
+  </preference>
+  <preference id="samtale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for samtale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for samtale</description>
+  </preference>
+  <preference id="sile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sile</description>
+  </preference>
+  <preference id="sipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sipe</description>
+  </preference>
+  <preference id="sjørøverskute_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sjørøverskute</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sjørøverskute</description>
+  </preference>
+  <preference id="skamfile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skamfile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skamfile</description>
+  </preference>
+  <preference id="skape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skape</description>
+  </preference>
+  <preference id="skarpslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skarpslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skarpslipe</description>
+  </preference>
+  <preference id="skjøne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skjøne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skjøne</description>
+  </preference>
+  <preference id="skjønne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skjønne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skjønne</description>
+  </preference>
+  <preference id="skrøne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skrøne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skrøne</description>
+  </preference>
+  <preference id="skråle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skråle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skråle</description>
+  </preference>
+  <preference id="skule_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skule</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skule</description>
+  </preference>
+  <preference id="skute_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skute</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skute</description>
+  </preference>
+  <preference id="skye_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skye</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skye</description>
+  </preference>
+  <preference id="skylde_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skylde</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skylde</description>
+  </preference>
+  <preference id="skåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for skåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for skåle</description>
+  </preference>
+  <preference id="slemme_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for slemme</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for slemme</description>
+  </preference>
+  <preference id="slepe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for slepe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for slepe</description>
+  </preference>
+  <preference id="slipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for slipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for slipe</description>
+  </preference>
+  <preference id="slute_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for slute</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for slute</description>
+  </preference>
+  <preference id="smake_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for smake</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for smake</description>
+  </preference>
+  <preference id="smie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for smie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for smie</description>
+  </preference>
+  <preference id="småkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for småkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for småkoke</description>
+  </preference>
+  <preference id="småspise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for småspise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for småspise</description>
+  </preference>
+  <preference id="snuse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for snuse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for snuse</description>
+  </preference>
+  <preference id="snøbake_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for snøbake</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for snøbake</description>
+  </preference>
+  <preference id="sope_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sope</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sope</description>
+  </preference>
+  <preference id="spare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for spare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for spare</description>
+  </preference>
+  <preference id="spele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for spele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for spele</description>
+  </preference>
+  <preference id="spike_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for spike</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for spike</description>
+  </preference>
+  <preference id="spise_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for spise</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for spise</description>
+  </preference>
+  <preference id="spjære_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for spjære</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for spjære</description>
+  </preference>
+  <preference id="sprele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sprele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sprele</description>
+  </preference>
+  <preference id="sprene_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sprene</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sprene</description>
+  </preference>
+  <preference id="sprøyte_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for sprøyte</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for sprøyte</description>
+  </preference>
+  <preference id="stire_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for stire</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for stire</description>
+  </preference>
+  <preference id="stole_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for stole</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for stole</description>
+  </preference>
+  <preference id="storspele_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for storspele</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for storspele</description>
+  </preference>
+  <preference id="stræne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for stræne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for stræne</description>
+  </preference>
+  <preference id="stråle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for stråle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for stråle</description>
+  </preference>
+  <preference id="suse_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for suse</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for suse</description>
+  </preference>
+  <preference id="svare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for svare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for svare</description>
+  </preference>
+  <preference id="tale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tale</description>
+  </preference>
+  <preference id="tape_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tape</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tape</description>
+  </preference>
+  <preference id="tilbakebetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tilbakebetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tilbakebetale</description>
+  </preference>
+  <preference id="tilmåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tilmåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tilmåle</description>
+  </preference>
+  <preference id="tilsvare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tilsvare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tilsvare</description>
+  </preference>
+  <preference id="tiltale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tiltale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tiltale</description>
+  </preference>
+  <preference id="tine_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tine</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tine</description>
+  </preference>
+  <preference id="tole_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tole</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tole</description>
+  </preference>
+  <preference id="trale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for trale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for trale</description>
+  </preference>
+  <preference id="trykkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for trykkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for trykkoke</description>
+  </preference>
+  <preference id="trylle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for trylle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for trylle</description>
+  </preference>
+  <preference id="turrbanne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for turrbanne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for turrbanne</description>
+  </preference>
+  <preference id="turrkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for turrkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for turrkoke</description>
+  </preference>
+  <preference id="tverrstane_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tverrstane</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tverrstane</description>
+  </preference>
+  <preference id="tvile_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tvile</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tvile</description>
+  </preference>
+  <preference id="tylle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tylle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tylle</description>
+  </preference>
+  <preference id="tynne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tynne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tynne</description>
+  </preference>
+  <preference id="tynnslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tynnslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tynnslipe</description>
+  </preference>
+  <preference id="tøle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tøle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tøle</description>
+  </preference>
+  <preference id="tørrbanne_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tørrbanne</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tørrbanne</description>
+  </preference>
+  <preference id="tørrkoke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for tørrkoke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for tørrkoke</description>
+  </preference>
+  <preference id="ule_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for ule</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for ule</description>
+  </preference>
+  <preference id="underbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for underbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for underbetale</description>
+  </preference>
+  <preference id="utbetale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for utbetale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for utbetale</description>
+  </preference>
+  <preference id="uthole_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for uthole</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for uthole</description>
+  </preference>
+  <preference id="utmerke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for utmerke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for utmerke</description>
+  </preference>
+  <preference id="utmåle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for utmåle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for utmåle</description>
+  </preference>
+  <preference id="utrope_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for utrope</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for utrope</description>
+  </preference>
+  <preference id="utstråle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for utstråle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for utstråle</description>
+  </preference>
+  <preference id="uttale_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for uttale</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for uttale</description>
+  </preference>
+  <preference id="vake_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vake</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vake</description>
+  </preference>
+  <preference id="vare_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vare</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vare</description>
+  </preference>
+  <preference id="vasslipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vasslipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vasslipe</description>
+  </preference>
+  <preference id="vass-slipe_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vass-slipe</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vass-slipe</description>
+  </preference>
+  <preference id="vegleie_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vegleie</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vegleie</description>
+  </preference>
+  <preference id="virke_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for virke</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for virke</description>
+  </preference>
+  <preference id="vræle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for vræle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for vræle</description>
+  </preference>
+  <preference id="øle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for øle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for øle</description>
+  </preference>
+  <preference id="åle_er_ar">
+    <description lang="nno">-er/-te/-t → -ar/-a/-a for åle</description>
+    <description lang="nob">-er/-te/-t → -ar/-a/-a for åle</description>
+  </preference>
+  <preference id="_er_ar">
+    <description lang="nno">system: roper → ropar, stader → stadar (-er/-te/-t → -ar/-a/-a der det er mogleg)</description>
+    <description lang="nob">system: roper → ropar, stader → stadar (-er/-te/-t → -ar/-a/-a der det er mulig)</description>
   </preference>
   <preference id="stader_stadar.subst-ene2ane">
     <description lang="nno">stader → stadar, stadene → stadane (systemrett fleirtalsform i hankjønnsord på -er/-ene)</description>


### PR DESCRIPTION
Some preferences are set in paradigms that affect lots of lemmas, but we'd like to be able to set them individually per lemma. But we don't want to pollute the .dix file with lots of new paradigms that only differ in the lemma-specific name of the preference sdef. E.g. "koke" and "skrøne" and many other words use the same pardef "ål/e__vblex" which has the "er_ar" variant on the present tense entry, we don't want to have to make individual pardefs and variant sdefs for each to be able to say that "only these 5 lemmas should have er_ar".

This commit renames the preference `er_ar` to `_er_ar` in dix to signify that it can be prepended by a lemma; if the variable `_er_ar` is set, we select the preference as usual for all affected lemmas, but if only the variable `koke_er_ar` is set, the preference is only selected for the lemma "koke"; if `koke_er_ar,skrøne_er_ar` are set then it affects both those lemmas etc.

```sh
$ export AP_SETVAR
$ for AP_SETVAR in  ""  "koke_er_ar"  "skrøne_er_ar"  "koke_er_ar,skrøne_er_ar"  "_er_ar" ; do 
    echo "$(echo han koker, hun skrøner| apertium -d . nob-nno)  AP_SETVAR=$AP_SETVAR";
done
han koker, ho skrøner   AP_SETVAR=
han kokar, ho skrøner   AP_SETVAR=koke_er_ar
han koker, ho skrønar   AP_SETVAR=skrøne_er_ar
han kokar, ho skrønar   AP_SETVAR=koke_er_ar,skrøne_er_ar
han kokar, ho skrønar   AP_SETVAR=_er_ar
```

Currently requires listing the affected lemmas explicitly in rlx and preferences.xml. If we had https://github.com/GrammarSoft/cg3/issues/109 we could at least avoid the rlx redundancy (though we may still want to have some explicit overrides like selecting `vasslipe` if `slipe_er_ar`)